### PR TITLE
Task not displayed in task list (ie. 'rake -T') in some environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ In your `Rakefile`:
 
     require "gem_publisher"
 
+    desc "Publish gem to RubyGems.org"
     task :publish_gem do |t|
       gem = GemPublisher.publish_if_updated("yourgem.gemspec", :rubygems)
       puts "Published #{gem}" if gem


### PR DESCRIPTION
In some environments a task may not be displayed by 'rake -T' unless
a description for the task is set.
