### PR TITLE
Make Publisher#version_released? method public

### DIFF
--- a/lib/gem_publisher/publisher.rb
+++ b/lib/gem_publisher/publisher.rb
@@ -25,7 +25,6 @@ module GemPublisher
       }
     end
 
-  private
     def version_released?
       releases = @git_remote.tags.
         select { |t| t =~ /^v\d+(\.\d+)+/ }.


### PR DESCRIPTION
This will allow gem_publisher to be used with more complex build/release workflows.

Also removed a redundant method.
