### PR TITLE
Fix binding when determining version from gemspec

### DIFF
--- a/lib/gem_publisher/publisher.rb
+++ b/lib/gem_publisher/publisher.rb
@@ -6,11 +6,12 @@ require "rubygems/specification"
 module GemPublisher
   class Publisher
     attr_accessor :git_remote, :builder, :pusher
+    attr_reader :version
 
     def initialize(gemspec)
       @gemspec = gemspec
 
-      @version = eval(File.read(gemspec)).version.to_s
+      @version = eval(File.read(gemspec), TOPLEVEL_BINDING).version.to_s
 
       @git_remote = GitRemote.new
       @builder    = Builder.new

--- a/test/data/toplevel_version.gemspec
+++ b/test/data/toplevel_version.gemspec
@@ -1,0 +1,12 @@
+gemspec = Gem::Specification.new do |s|
+  s.name              = 'toplevel_version'
+  s.version           = VERSION
+  s.summary           = 'summary'
+  s.description       = 'description'
+  s.files             = []
+  s.require_path      = 'lib'
+  s.has_rdoc          = true
+  s.homepage          = 'http://example.com'
+  s.authors           = ['Luther Blisset']
+  s.email             = 'user@example.com'
+end

--- a/test/publisher_test.rb
+++ b/test/publisher_test.rb
@@ -78,5 +78,13 @@ module GemPublisher
       p.git_remote.expects(:add_tag).with("v0.0.3")
       assert_equal "foo-0.0.3.gem", p.publish_if_updated(:method)
     end
+
+    ::VERSION = "0.2.3"
+    def test_should_eval_gemspec_in_root_context
+      # Previously this would pick up GemPublisher::VERSION incorrectly
+      p = Publisher.new(data_file_path("toplevel_version.gemspec"))
+
+      assert_equal "0.2.3", p.version
+    end
   end
 end


### PR DESCRIPTION
Some gems don't use a namespaced `VERSION` constant.  When publishing these gems, gem_publisher would push a tag with it's own version instead of the gem's version.  This is because the gemspec was evaled within the
`GemPublisher` module, and therefore the `GemPublisher::VERSION` constant was picked up.

Admittedly, these gems aren't well written, but picking up gem_publisher's version is definitely an error.

eval'ing with the `TOPLEVEL_BINDING` solves this.
