### PR TITLE
Include stdout in error messages

### DIFF
--- a/lib/gem_publisher/cli_facade.rb
+++ b/lib/gem_publisher/cli_facade.rb
@@ -9,7 +9,7 @@ module GemPublisher
       cmd = Shellwords.join(arguments)
       stdout_str, stderr_str, status = Open3.capture3(cmd)
       if status.exitstatus > 0
-        raise Error, stderr_str
+        raise Error, [stderr_str, stdout_str].join("\n").strip
       end
       stdout_str
     end

--- a/test/cli_facade_test.rb
+++ b/test/cli_facade_test.rb
@@ -11,6 +11,21 @@ module GemPublisher
       end
     end
 
+    def test_should_include_all_output_in_error
+      status = stub(exitstatus: 1)
+      Open3.stubs(:capture3).returns(["stdout", "stderr", status])
+      err = assert_raises CliFacade::Error do
+        CliFacade.new.execute("status")
+      end
+      assert_equal "stderr\nstdout", err.message
+
+      Open3.stubs(:capture3).returns(["stdout", "", status])
+      err = assert_raises CliFacade::Error do
+        CliFacade.new.execute("status")
+      end
+      assert_equal "stdout", err.message
+    end
+
     def test_should_return_stdout_if_command_succeeded
       status = stub(exitstatus: 0)
       Open3.stubs(:capture3).returns(["stdout", "stderr", status])


### PR DESCRIPTION
Some of the tools used (eg gem push) output everything to stdout on error.  This change enables us to still return a meaningful error message in this case.

Fixes #8
