### PR TITLE
Pin Mocha development dependency

### DIFF
--- a/gem_publisher.gemspec
+++ b/gem_publisher.gemspec
@@ -11,6 +11,6 @@ gemspec = Gem::Specification.new do |s|
   s.homepage          = 'http://github.com/alphagov/gem_publisher'
   s.authors           = ['Paul Battley']
   s.email             = "pbattley@gmail.com"
-  s.add_development_dependency 'mocha'
+  s.add_development_dependency 'mocha', '0.14.0'
   s.add_development_dependency 'rake'
 end

--- a/test/common.rb
+++ b/test/common.rb
@@ -2,7 +2,7 @@ lib = File.expand_path("../../lib", __FILE__)
 $:.unshift lib unless $:.include?(lib)
 
 require "minitest/autorun"
-require "mocha"
+require "mocha/setup"
 
 class MiniTest::Unit::TestCase
   def data_file(name)


### PR DESCRIPTION
Version 1.0.0 of Mocha appears to have backwards-incompatible changes;
pinning these for now to fix the build; we can diagnose the breakage in
more depth later.

Also fix the `require` statement in the test setup, which triggers a
deprecation warning.
