### PR TITLE
Release version 1.4.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+* Add a `tag_prefix` option to support tag conventions other than `v1.4.0`
+
 ## 1.3.2
 
 * Pin Mocha development dependency to fix test failures

--- a/lib/gem_publisher/version.rb
+++ b/lib/gem_publisher/version.rb
@@ -1,3 +1,3 @@
 module GemPublisher
-  VERSION = "1.3.2"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
Along with a changelog, for good measure.

We should _probably_ merge this after #13, but I don’t think it matters too much either way.
