### PR TITLE
Bump minitest version

### DIFF
--- a/gem_publisher.gemspec
+++ b/gem_publisher.gemspec
@@ -12,6 +12,6 @@ gemspec = Gem::Specification.new do |s|
   s.homepage          = 'http://github.com/alphagov/gem_publisher'
   s.authors           = ['Government Digital Service']
   s.add_development_dependency 'mocha', '0.14.0'
-  s.add_development_dependency 'minitest', '~> 2.5.1'
+  s.add_development_dependency 'minitest', '~> 4.0'
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Newer versions of rubygems [require minitest ~> 4.0](https://github.com/ruby/ruby/blob/ruby_2_1/lib/rubygems/test_case.rb#L3-L7) in the test case helper (which we use for testing the rubygems plugin).