### PR TITLE
Push a branch as alias of the latest release tag

### DIFF
--- a/lib/gem_publisher/git_remote.rb
+++ b/lib/gem_publisher/git_remote.rb
@@ -18,6 +18,12 @@ module GemPublisher
       git "push", @remote_name, "tag", tag_name
     end
 
+    def add_branch(branch_name, commit_ish = "HEAD")
+      sha1 = git("rev-parse", commit_ish).chomp
+      git "push", @remote_name, "#{sha1}:refs/heads/#{branch_name}"
+    end
+
+
   private
     def git(*args)
       @cli_facade.execute(*["git"] + args)

--- a/lib/gem_publisher/publisher.rb
+++ b/lib/gem_publisher/publisher.rb
@@ -10,9 +10,11 @@ module GemPublisher
 
     # Supported options:
     #   :tag_prefix - use a custom prefix for Git tags (defaults to 'v')
+    #   :latest_alias_branch - a branch to alias the most recent release (defaults to 'latest-release')
     def initialize(gemspec, options = {})
       @gemspec = gemspec
       @tag_prefix = options[:tag_prefix] || 'v'
+      @latest_alias_branch = options[:latest_alias_branch] || 'latest-release'
 
       @version = eval(File.read(gemspec), TOPLEVEL_BINDING).version.to_s
 
@@ -31,6 +33,7 @@ module GemPublisher
         tag_prefix = options[:tag_prefix] || 'v'
         @pusher.push gem, method, options
         @git_remote.add_tag "#{@tag_prefix}#{@version}"
+        @git_remote.add_branch @latest_alias_branch
       }
     end
 

--- a/test/git_remote_test.rb
+++ b/test/git_remote_test.rb
@@ -28,5 +28,18 @@ module GemPublisher
       remote = GitRemote.new("origin", cli_facade)
       remote.add_tag("nameoftag")
     end
+
+    def test_should_push_branch_to_remote
+      cli_facade = mock
+      sha1 = "5294fac0c70956209494b69bc1a8c38192f6a931"
+      cli_facade.stubs(:execute).
+        with("git", "rev-parse", "HEAD").
+        returns("#{sha1}\n")
+      cli_facade.expects(:execute).
+        with("git", "push", "origin", "#{sha1}:refs/heads/nameofbranch")
+
+      remote = GitRemote.new("origin", cli_facade)
+      remote.add_branch("nameofbranch")
+    end
   end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -21,6 +21,8 @@ module GemPublisher
       expect_cli "git rev-parse HEAD", "1234abcd"
       expect_cli "git update-ref refs/tags/v0.0.3 1234abcd"
       expect_cli "git push origin tag v0.0.3"
+      expect_cli "git rev-parse HEAD", "1234abcd"
+      expect_cli "git push origin 1234abcd:refs/heads/latest-release"
       GemPublisher.publish_if_updated gemspec
     end
 
@@ -32,6 +34,8 @@ module GemPublisher
       expect_cli "git rev-parse HEAD", "1234abcd"
       expect_cli "git update-ref refs/tags/v0.0.3 1234abcd"
       expect_cli "git push origin tag v0.0.3"
+      expect_cli "git rev-parse HEAD", "1234abcd"
+      expect_cli "git push origin 1234abcd:refs/heads/latest-release"
       GemPublisher.publish_if_updated gemspec, :gemfury
     end
 
@@ -43,6 +47,8 @@ module GemPublisher
       expect_cli "git rev-parse HEAD", "1234abcd"
       expect_cli "git update-ref refs/tags/v0.0.3 1234abcd"
       expect_cli "git push origin tag v0.0.3"
+      expect_cli "git rev-parse HEAD", "1234abcd"
+      expect_cli "git push origin 1234abcd:refs/heads/latest-release"
       GemPublisher.publish_if_updated gemspec, :gemfury, :as => "foo"
     end
   end

--- a/test/publisher_test.rb
+++ b/test/publisher_test.rb
@@ -39,6 +39,7 @@ module GemPublisher
       p.git_remote = mock
       p.git_remote.stubs(:tags).returns(%w[v0.0.1 v0.0.2])
       p.git_remote.expects(:add_tag).with("v0.0.3")
+      p.git_remote.expects(:add_branch).with("latest-release")
       assert_equal "foo-0.0.3.gem", p.publish_if_updated(:method)
     end
 
@@ -52,6 +53,7 @@ module GemPublisher
       p.git_remote = mock
       p.git_remote.stubs(:tags).returns(%w[v0.0.1 v0.0.2])
       p.git_remote.stubs(:add_tag)
+      p.git_remote.stubs(:add_branch)
       assert_equal "foo-0.0.3.gem", p.publish_if_updated(:method, :foo => "bar")
     end
 
@@ -64,6 +66,7 @@ module GemPublisher
       p.git_remote = mock
       p.git_remote.stubs(:tags).returns([])
       p.git_remote.expects(:add_tag).with("v0.0.3")
+      p.git_remote.expects(:add_branch).with("latest-release")
       assert_equal "foo-0.0.3.gem", p.publish_if_updated(:method)
     end
 
@@ -76,6 +79,7 @@ module GemPublisher
       p.git_remote = mock
       p.git_remote.stubs(:tags).returns(%w[v0.0.1 v0.0.2 v0.1.0])
       p.git_remote.expects(:add_tag).with("v0.0.3")
+      p.git_remote.expects(:add_branch).with("latest-release")
       assert_equal "foo-0.0.3.gem", p.publish_if_updated(:method)
     end
 
@@ -88,6 +92,20 @@ module GemPublisher
       p.git_remote = mock
       p.git_remote.stubs(:tags).returns(%w[prefix0.0.1 prefix0.0.2 prefix0.1.0])
       p.git_remote.expects(:add_tag).with("prefix0.0.3")
+      p.git_remote.expects(:add_branch).with("latest-release")
+      assert_equal "foo-0.0.3.gem", p.publish_if_updated(:method)
+    end
+
+    def test_should_publish_latest_branch_if_given
+      p = Publisher.new(data_file_path("example.gemspec"), :latest_alias_branch => "latest")
+      p.builder = mock
+      p.builder.expects(:build).returns("foo-0.0.3.gem")
+      p.pusher = mock
+      p.pusher.expects(:push).with("foo-0.0.3.gem", :method, {})
+      p.git_remote = mock
+      p.git_remote.stubs(:tags).returns(%w[v.0.1 v.0.2 v0.1.0])
+      p.git_remote.expects(:add_tag).with("v0.0.3")
+      p.git_remote.expects(:add_branch).with("latest")
       assert_equal "foo-0.0.3.gem", p.publish_if_updated(:method)
     end
 


### PR DESCRIPTION
This is to make diffing master against  whatever the latest released version
of the package is. This allows us to easily see what has been committed to
master but not yet released in a consistent way, eg with a diff like:

https://github.com/alphagov/govuk_frontend_toolkit/compare/latest-release...master

Which means we don't need to know the latest release is tag `v4.10.0` (for example)

For deployed applications we track some alias branches, like `deployed-to-production`
that are set during the deploy jobs, which allow us to do the same thing, and is used
by tools like the deploy-lag-radiator (https://github.com/dsingleton/deploy-lag-radiator)
to visualise when code hasn't been deployed.

Code hanging around has caused us problems in the past, the deploy-lag-radiator helped
a lot for deployed apps, this attempts to do the same for gems.

**Note**: The changes are a bit scrappy. The tests pass but i'd appreciate someone a bit more familiar with the project to give it a good look, CC @alext (sorry, you're the last contributor in the building).